### PR TITLE
Colon missing

### DIFF
--- a/generators/app/templates/root/main/apps.py
+++ b/generators/app/templates/root/main/apps.py
@@ -1,5 +1,5 @@
 
 from django.apps import AppConfig
 
-class MainConfig(AppConfig)
+class MainConfig(AppConfig):
 	name = "<%= appName %>"


### PR DESCRIPTION
The app wasn't registering because of this, but adding a colon fixed it.